### PR TITLE
The current Exception class ironically throw an ErrorException when loaded

### DIFF
--- a/classes/exception.php
+++ b/classes/exception.php
@@ -9,7 +9,7 @@
 
 namespace OAuth2;
 
-class Exception extends Exception {
+class Exception extends \Exception {
 
 	/**
 	 * The result from the API server that represents the exception information.
@@ -43,7 +43,7 @@ class Exception extends Exception {
 			$message = 'Unknown Error.';
 		}
 
-		parent::__construct($message, $code);
+		parent::__construct($message, (int) $code);
 	}
 
 	/**


### PR DESCRIPTION
The parent Exception class is in the global namespace. The error code must be explicitly cast to int otherwise some PHP version complains.
