### PR TITLE
Patch/google OAuth2

### DIFF
--- a/classes/provider.php
+++ b/classes/provider.php
@@ -183,7 +183,8 @@ abstract class Provider {
 				$opts = array(
 					'http' => array(
 						'method'  => 'POST',
-						'header'  => 'Content-type: application/x-www-form-urlencoded',
+						'header'  => 'Content-type: application/x-www-form-urlencoded\r\n'
+							."Content-Length: ".strlen($postdata)."\r\n",
 						'content' => $postdata
 					)
 				);

--- a/classes/provider/google.php
+++ b/classes/provider/google.php
@@ -9,6 +9,8 @@ class Provider_Google extends Provider {
 	public $uid_key = 'uid';
 	
 	public $method = 'POST';
+
+	public $scope_seperator = ' ';
 	
 	public $scope = 'https://www.googleapis.com/auth/plus.me';
 

--- a/classes/provider/google.php
+++ b/classes/provider/google.php
@@ -24,14 +24,33 @@ class Provider_Google extends Provider {
 		return 'https://accounts.google.com/o/oauth2/token';
 	}
 
+	/*
+	* Get an authorization code from Facebook.  Redirects to Facebook, which this redirects back to the app using the redirect address you've set.
+	*/	
 	public function authorize($options = array())
 	{
 		if (null === $this->scope or empty($this->scope))
 		{
 			throw new Exception('Required option not provided: scope');
 		}
-		
+
 		parent::authorize($options);
+	}
+
+	/*
+	* Get access to the API
+	*
+	* @param	string	The access code
+	* @return	object	Success or failure along with the response details
+	*/	
+	public function access($code, $options = array())
+	{
+		if (null === $code)
+		{
+			throw new Exception('Expected Authorization Code from '.ucfirst($this->name).' is missing');
+		}
+
+		parent::access($code, $options);
 	}
 
 	public function get_user_info($token)

--- a/classes/provider/google.php
+++ b/classes/provider/google.php
@@ -50,7 +50,7 @@ class Provider_Google extends Provider {
 			throw new Exception('Expected Authorization Code from '.ucfirst($this->name).' is missing');
 		}
 
-		parent::access($code, $options);
+		return parent::access($code, $options);
 	}
 
 	public function get_user_info($token)

--- a/classes/provider/google.php
+++ b/classes/provider/google.php
@@ -24,6 +24,16 @@ class Provider_Google extends Provider {
 		return 'https://accounts.google.com/o/oauth2/token';
 	}
 
+	public function authorize($options = array())
+	{
+		if (null === $this->scope or empty($this->scope))
+		{
+			throw new Exception('Required option not provided: scope');
+		}
+		
+		parent::authorize($options);
+	}
+
 	public function get_user_info($token)
 	{
 		$url = 'https://www.googleapis.com/plus/v1/people/me?'.http_build_query(array(


### PR DESCRIPTION
- Google OAuth2 use space as scope separator. (see http://code.google.com/apis/accounts/docs/OAuth2Login.html#formingtheurl)
- Avoid silent error from google, scope must be presented "error":"invalid_request","error_description":"Missing required parameter: scope","error_uri":"http:\/\/code.google.com\/apis\/accounts\/docs\/OAuth2.html"
- void another silent error from Google, authorization code must be presented before sending an access token request
